### PR TITLE
Fix DA alert

### DIFF
--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -21838,9 +21838,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json5@npm:1.0.1"
+"json5@npm:2.2.2":
+  version: 2.2.2
+  resolution: "json5@npm:2.2.2"
   dependencies:
     minimist: ^1.2.0
   bin:

--- a/test-storybooks/external-docs/yarn.lock
+++ b/test-storybooks/external-docs/yarn.lock
@@ -3278,9 +3278,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json5@npm:^0.0.29":
-  version: 0.0.29
-  resolution: "@types/json5@npm:0.0.29"
+"@types/json5@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@types/json5@npm:2.2.2"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
   languageName: node
   linkType: hard

--- a/test-storybooks/server-kitchen-sink/yarn.lock
+++ b/test-storybooks/server-kitchen-sink/yarn.lock
@@ -6929,9 +6929,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "json5@npm:2.2.1"
+`json5@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "json5@npm:2.2.2"
   bin:
     json5: lib/cli.js
   checksum: 74b8a23b102a6f2bf2d224797ae553a75488b5adbaee9c9b6e5ab8b510a2fc6e38f876d4c77dea672d4014a44b2399e15f2051ac2b37b87f74c0c7602003543b

--- a/test-storybooks/standalone-preview/yarn.lock
+++ b/test-storybooks/standalone-preview/yarn.lock
@@ -8441,9 +8441,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.2.0, json5@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "json5@npm:2.2.1"
+"json5@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "json5@npm:2.2.2"
   bin:
     json5: lib/cli.js
   checksum: 74b8a23b102a6f2bf2d224797ae553a75488b5adbaee9c9b6e5ab8b510a2fc6e38f876d4c77dea672d4014a44b2399e15f2051ac2b37b87f74c0c7602003543b


### PR DESCRIPTION
Update `json5` to `2.2.2` (first non-vulnerable) version